### PR TITLE
Fix typos in Kalman filter chapter and a few other places

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ as a digest of graduate-level control theory aimed at veteran FIRST Robotics
 Competition (FRC) students who know algebra and a bit of physics. As I learned
 the subject of control theory, I found that it wasn't particularly difficult,
 but very few resources exist outside of academia for learning it. This book is
-intended to rectify that situation and provide a lower the barrier to entry to
-the field.
+intended to rectify that situation and lower the barrier to entry to the field.
 
 This book reads a lot like a reference manual on control theory and related
 tools. It teaches the reader how to start designing and implementing control

--- a/estimation-and-localization/pose-estimation/pose-exponential.tex
+++ b/estimation-and-localization/pose-estimation/pose-exponential.tex
@@ -375,7 +375,7 @@ of the current heading, which is along the x-axis. Therefore,
   \end{bmatrix}} &=
   \begin{bmatrix}
     v_x t \cos\theta \\
-    v_y t \sin\theta \\
+    v_x t \sin\theta \\
     \omega t
   \end{bmatrix}
 \end{align*}

--- a/estimation-and-localization/stochastic-control-theory/introduction-to-probability.tex
+++ b/estimation-and-localization/stochastic-control-theory/introduction-to-probability.tex
@@ -91,7 +91,7 @@ The standard deviation is the square root of the variance.
 \index{probability!probability density functions}
 
 Probability density functions can also include more than one variable. Let $x$
-and $y$ are random variables. The joint probability density function $p(x, y)$
+and $y$ be random variables. The joint probability density function $p(x, y)$
 defines the probability $p(x, y) \,dx \,dy$, so that $x$ and $y$ are in the
 intervals $x \in [x, x + dx], y \in [y, y + dy]$. In other words, the
 probability is the volume under a region of the PDF manifold (see figure

--- a/estimation-and-localization/stochastic-control-theory/kalman-filter.tex
+++ b/estimation-and-localization/stochastic-control-theory/kalman-filter.tex
@@ -96,7 +96,7 @@ Now just evaluate the covariances.
 \subsubsection{Finding the optimal Kalman gain}
 
 The error in the \textit{a posteriori} \gls{state} estimation is
-$\mat{x}_{k+1} - \hat{\mat{x}}_{k+1}^-$. We want to minimize the expected value
+$\mat{x}_{k+1} - \hat{\mat{x}}_{k+1}^+$. We want to minimize the expected value
 of the square of the magnitude of this vector. This is equivalent to minimizing
 the trace of the a posteriori estimate covariance matrix $\mat{P}_{k+1}^+$.
 
@@ -144,17 +144,24 @@ Expand terms.
 \end{align*}
 
 Factor out $\mat{K}_{k+1}$ and $\mat{K}_{k+1}^T$.
-\begin{align}
+\begin{align*}
   \mat{P}_{k+1}^+ &=
     \mat{P}_{k+1}^- - \mat{P}_{k+1}^-\mat{C}_{k+1}^T\mat{K}_{k+1}^T -
     \mat{K}_{k+1}\mat{C}_{k+1}\mat{P}_{k+1}^- \nonumber \\
     &\qquad + \mat{K}_{k+1}(\mat{C}_{k+1}\mat{P}_{k+1}^-\mat{C}_{k+1}^T +
-    \mat{R}_{k+1})\mat{K}_{k+1}^T \nonumber \\
-  \mat{P}_{k+1}^+ &=
+    \mat{R}_{k+1})\mat{K}_{k+1}^T
+\end{align*}
+
+$\mat{C}_{k+1}\mat{P}_{k+1}^-\mat{C}_{k+1}^T + \mat{R}_{k+1}$ is the innovation
+(measurement residual) covariance at timestep $k + 1$. We'll let this expression
+equal $\mat{S}_{k+1}$. We won't need it in the final theorem, but it makes the
+derivations after this point more concise.
+\begin{equation}
+  \mat{P}_{k+1}^+ =
     \mat{P}_{k+1}^- - \mat{P}_{k+1}^-\mat{C}_{k+1}^T\mat{K}_{k+1}^T -
     \mat{K}_{k+1}\mat{C}_{k+1}\mat{P}_{k+1}^- +
     \mat{K}_{k+1}\mat{S}_{k+1}\mat{K}_{k+1}^T \label{eq:post_p_update}
-\end{align}
+\end{equation}
 
 Now take the trace.
 \begin{equation*}
@@ -222,7 +229,8 @@ derivative with respect to $\mat{K}$ and setting the result to $\mat{0}$.
 
 This is the optimal Kalman gain.
 
-\subsubsection{Simplified \textit{a priori} estimate covariance update equation}
+\subsubsection{Simplified \textit{a posteriori} estimate covariance update
+  equation}
 
 If the optimal Kalman gain is used, the \textit{a posteriori} estimate
 covariance matrix update equation can be simplified. First, we'll manipulate the

--- a/estimation-and-localization/stochastic-control-theory/linear-stochastic-systems.tex
+++ b/estimation-and-localization/stochastic-control-theory/linear-stochastic-systems.tex
@@ -19,7 +19,7 @@ where $\mat{w}_k$ is the process noise and $\mat{v}_k$ is the measurement noise,
 
 where $\mat{Q}_k$ is the process noise covariance matrix and $\mat{R}_k$ is the
 measurement noise covariance matrix. We assume the noise samples are
-independent, so $E[\mat{w}_k\mat{w}_j^T] = 0$ and $E[\mat{v}_k\mat{v}_k^T] = 0$
+independent, so $E[\mat{w}_k\mat{w}_j^T] = 0$ and $E[\mat{v}_k\mat{v}_j^T] = 0$
 where $k \neq j$. Furthermore, process noise samples are independent from
 measurement noise samples.
 

--- a/estimation-and-localization/stochastic-control-theory/two-sensor-problem.tex
+++ b/estimation-and-localization/stochastic-control-theory/two-sensor-problem.tex
@@ -25,10 +25,10 @@ measurement. The expected value is a reasonable estimator of $x$.
 \end{align}
 
 Note that the weights $w_1$ and $w_2$ sum to $1$. When the prior (i.e., prior
-knowledge of \gls{state}) is uninformative (a large variance)
+knowledge of \gls{state}) is uninformative (a large variance),
 \begin{align}
-  w_1 &= \lim_{\sigma_0^2 \to 0} \frac{\sigma_0^2}{\sigma_0^2 + \sigma^2} = 0 \\
-  w_2 &= \lim_{\sigma_0^2 \to 0} \frac{\sigma^2}{\sigma_0^2 + \sigma^2} = 1
+  w_1 &= \lim_{\sigma_0^2 \to \infty} \frac{\sigma_0^2}{\sigma_0^2 + \sigma^2} = 1 \\
+  w_2 &= \lim_{\sigma_0^2 \to \infty} \frac{\sigma^2}{\sigma_0^2 + \sigma^2} = 0
 \end{align}
 
 and $\hat{x} = z_1$. That is, the weight is on the observations and the estimate
@@ -37,8 +37,8 @@ is equal to the measurement.
 Let us assume we have a \gls{model} providing an almost exact prior for $x$. In
 that case, $\sigma_0^2$ approaches 0 and
 \begin{align}
-  w_1 &= \lim_{\sigma_0^2 \to 0} \frac{\sigma_0^2}{\sigma_0^2 + \sigma^2} = 1 \\
-  w_2 &= \lim_{\sigma_0^2 \to 0} \frac{\sigma^2}{\sigma_0^2 + \sigma^2} = 0
+  w_1 &= \lim_{\sigma_0^2 \to 0} \frac{\sigma_0^2}{\sigma_0^2 + \sigma^2} = 0 \\
+  w_2 &= \lim_{\sigma_0^2 \to 0} \frac{\sigma^2}{\sigma_0^2 + \sigma^2} = 1
 \end{align}
 
 The Kalman filter uses this optimal fusion as the basis for its operation.

--- a/modern-control-theory/linear-algebra/misc-notation.tex
+++ b/modern-control-theory/linear-algebra/misc-notation.tex
@@ -29,3 +29,8 @@ The $^\dagger$ in $\mat{B}^\dagger$ denotes the Moore-Penrose pseudoinverse
 given by $\mat{B}^\dagger = (\mat{B}^T\mat{B})^{-1}\mat{B}^T$. The pseudoinverse
 is used when the matrix is nonsquare and thus not invertible to produce a close
 approximation of an inverse in the least squares sense.
+
+\index{matrices!trace}
+$\tr(\mat{A})$ denotes the trace of the square matrix $\mat{A}$, which is
+defined as the sum of the elements on the main diagonal (top-left to
+bottom-right).

--- a/modern-control-theory/ss-applications/flywheel.tex
+++ b/modern-control-theory/ss-applications/flywheel.tex
@@ -168,7 +168,7 @@ Therefore,
 \end{theorem}
 
 Notice that in this \gls{model}, the \gls{output} doesn't provide any direct
-measurements of the \gls{state}. To estimate the full \gls{state} (alsa known as
+measurements of the \gls{state}. To estimate the full \gls{state} (also known as
 full observability), we only need the \glspl{output} to collectively include
 linear combinations of every \gls{state}\footnote{While the flywheel model's
 outputs are a linear combination of both the states and inputs, \glspl{input}


### PR DESCRIPTION
Also define the trace of a matrix and the innovation covariance S where
it's used.

Fixes #14.