### PR TITLE
Shrink mainmatter if statement in styles.tex

### DIFF
--- a/preamble/styles.tex
+++ b/preamble/styles.tex
@@ -415,46 +415,26 @@
 \def\@makechapterhead#1{{%
   \parindent \z@ \raggedright \normalfont
   \ifnum \c@secnumdepth >\m@ne
-    \if@mainmatter
-      \begin{tikzpicture}[remember picture,overlay]
-        \node at (current page.north west){%
-          \begin{tikzpicture}[remember picture,overlay]
-            \node[anchor=north west,inner sep=0pt] at (0,0)%
-              {\ifusechapterimage\includegraphics[width=\paperwidth]%
-               {\thechapterimage}\fi};
-            \draw[anchor=west] (\paperwidth*0.6,-0.5cm) node [line width=2pt,%
-                rounded corners=5pt,fill=white,fill opacity=0.5,%
-                inner sep=0.5pt]{\strut\makebox[8.5cm]{}};
-            \draw[anchor=west] (\paperwidth*0.6,-0.5cm) node%
-              {\tiny\sffamily\bfseries\itshape\color{black}\thechapterimagecaption};
-            \draw[anchor=west] (\Gm@lmargin,-6cm) node%
-              [line width=2pt,rounded corners=15pt,draw=themecolor,fill=white,%
-               fill opacity=0.5,inner sep=15pt]{\strut\makebox[22cm]{}};
-            \draw[anchor=west] (\Gm@lmargin+.3cm,-6cm) node%
-              {\huge\sffamily\bfseries\color{black}\thechapter\autodot~#1\strut};
-          \end{tikzpicture}%
-        };
-      \end{tikzpicture}
-    \else
-      \begin{tikzpicture}[remember picture,overlay]
-        \node at (current page.north west){%
-          \begin{tikzpicture}[remember picture,overlay]
-            \node[anchor=north west,inner sep=0pt] at (0,0)%
-              {\ifusechapterimage\includegraphics[width=\paperwidth]%
-               {\thechapterimage}\fi};
-            \draw[anchor=west] (\paperwidth*0.6,-0.5cm) node [line width=2pt,%
-                rounded corners=5pt,fill=white,fill opacity=0.5,%
-                inner sep=0.5pt]{\strut\makebox[8.5cm]{}};
-            \draw[anchor=west] (\paperwidth*0.6,-0.5cm) node%
-              {\tiny\sffamily\bfseries\itshape\color{black}\thechapterimagecaption};
-            \draw[anchor=west] (\Gm@lmargin,-6cm) node%
-              [line width=2pt,rounded corners=15pt,draw=themecolor,fill=white,%
-               fill opacity=0.5,inner sep=15pt]{\strut\makebox[22cm]{}};
-            \draw[anchor=west] (\Gm@lmargin+.3cm,-6cm) node%
-              {\huge\sffamily\bfseries\color{black}#1\strut};
-          \end{tikzpicture}};
-      \end{tikzpicture}
-    \fi
+    \begin{tikzpicture}[remember picture,overlay]
+      \node at (current page.north west){%
+        \begin{tikzpicture}[remember picture,overlay]
+          \node[anchor=north west,inner sep=0pt] at (0,0)%
+            {\ifusechapterimage\includegraphics[width=\paperwidth]%
+             {\thechapterimage}\fi};
+          \draw[anchor=west] (\paperwidth*0.6,-0.5cm) node [line width=2pt,%
+              rounded corners=5pt,fill=white,fill opacity=0.5,%
+              inner sep=0.5pt]{\strut\makebox[8.5cm]{}};
+          \draw[anchor=west] (\paperwidth*0.6,-0.5cm) node%
+            {\tiny\sffamily\bfseries\itshape\color{black}\thechapterimagecaption};
+          \draw[anchor=west] (\Gm@lmargin,-6cm) node%
+            [line width=2pt,rounded corners=15pt,draw=themecolor,fill=white,%
+             fill opacity=0.5,inner sep=15pt]{\strut\makebox[22cm]{}};
+          \draw[anchor=west] (\Gm@lmargin+.3cm,-6cm) node%
+            {\huge\sffamily\bfseries\color{black}%
+            \if@mainmatter\thechapter\autodot~#1\strut};
+        \end{tikzpicture}%
+      };
+    \end{tikzpicture}
   \fi\par\vspace*{200\p@}}}
 
 %-------------------------------------------

--- a/preamble/styles.tex
+++ b/preamble/styles.tex
@@ -431,7 +431,7 @@
              fill opacity=0.5,inner sep=15pt]{\strut\makebox[22cm]{}};
           \draw[anchor=west] (\Gm@lmargin+.3cm,-6cm) node%
             {\huge\sffamily\bfseries\color{black}%
-            \if@mainmatter\thechapter\autodot~#1\strut};
+            \if@mainmatter\thechapter\autodot~\fi#1\strut};
         \end{tikzpicture}%
       };
     \end{tikzpicture}


### PR DESCRIPTION
There's an if statement that checks whether it's the mainmatter to determine whether to put the number of the chapter before the name of the chapter in the header (e.g. `5. Linear algebra` vs `Preface`), and that if includes the entire styling for the header and not just the number thing.