### PR TITLE
Remove motors.vex.com link

### DIFF
--- a/lint/check_links.py
+++ b/lint/check_links.py
@@ -44,11 +44,6 @@ def verify_url(filename, line_number, url):
         if r.status_code == 403 and url.startswith("https://www.researchgate.net"):
             return True
 
-        # motors.vex.com tends to block scripts, so don't return verification
-        # failure for its links
-        if r.status_code == 403 and url.startswith("https://motors.vex.com"):
-            return True
-
         # Allow redirects for YouTube shortlinks
         if r.status_code == 303 and url.startswith("https://youtu.be"):
             return True

--- a/lint/check_links.py
+++ b/lint/check_links.py
@@ -53,15 +53,7 @@ def verify_url(filename, line_number, url):
             if url != r.url:
                 print(f"    redirected to {r.url}")
             return False
-    except requests.ConnectionError as ex:
-        print(f"[{filename}:{line_number}]\n    {url}\n    {ex}")
-        return False
-    except requests.exceptions.Timeout as ex:
-        # motors.vex.com tends to time out for scripts, so don't return
-        # verification failure for its links
-        if url.startswith("https://motors.vex.com"):
-            return True
-
+    except (requests.ConnectionError, requests.exceptions.Timeout) as ex:
         print(f"[{filename}:{line_number}]\n    {url}\n    {ex}")
         return False
     return True

--- a/system-modeling/newtonian-mechanics-examples/dc-motor.tex
+++ b/system-modeling/newtonian-mechanics-examples/dc-motor.tex
@@ -75,8 +75,8 @@ Substitute this into equation \eqref{eq:motor_V}.
 
 A typical motor's datasheet should include graphs of the motor's measured torque
 and current for different angular velocities for a given voltage applied to the
-motor. Figure \ref{fig:motor_data} is an example. Data for motors in FRC can be
-found on the relevant vendors website.
+motor. Figure \ref{fig:motor_data} is an example. An FRC motor's datasheet can
+be found on its vendor's website.
 \begin{svg}{build/\chapterpath/motor_data}
   \caption{Example motor datasheet for 775pro}
   \label{fig:motor_data}

--- a/system-modeling/newtonian-mechanics-examples/dc-motor.tex
+++ b/system-modeling/newtonian-mechanics-examples/dc-motor.tex
@@ -75,8 +75,8 @@ Substitute this into equation \eqref{eq:motor_V}.
 
 A typical motor's datasheet should include graphs of the motor's measured torque
 and current for different angular velocities for a given voltage applied to the
-motor. Figure \ref{fig:motor_data} is an example. Data for the most common
-motors in FRC can be found at \url{https://motors.vex.com/}.
+motor. Figure \ref{fig:motor_data} is an example. Data for motors in FRC can be
+found on the relevant vendors website.
 \begin{svg}{build/\chapterpath/motor_data}
   \caption{Example motor datasheet for 775pro}
   \label{fig:motor_data}


### PR DESCRIPTION
motors.vex.com didn't really give me any useful information. I couldn't find a general source for FRC motor datasheets today so instead tell the user to check the relevant vendors site.